### PR TITLE
fix: fix bugs of init caused by lerna

### DIFF
--- a/packages/haechi-cli/referenceFiles/.solcover.js
+++ b/packages/haechi-cli/referenceFiles/.solcover.js
@@ -1,0 +1,9 @@
+// https://github.com/sc-forks/solidity-coverage
+module.exports = {
+  norpc: true,
+  testCommand:
+    'node --max-old-space-size=4096 ../node_modules/.bin/truffle test --network coverage',
+  compileCommand:
+    'node --max-old-space-size=4096 ../node_modules/.bin/truffle compile --network coverage',
+  copyPackages: ['openzeppelin-solidity']
+};

--- a/packages/haechi-cli/referenceFiles/.soliumignore
+++ b/packages/haechi-cli/referenceFiles/.soliumignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/haechi-cli/referenceFiles/.soliumrc.json
+++ b/packages/haechi-cli/referenceFiles/.soliumrc.json
@@ -1,0 +1,13 @@
+{
+  "extends": "solium:all",
+  "plugins": ["security"],
+  "rules": {
+    "arg-overflow": ["warning", 3],
+    "indentation": ["error", 4],
+    "quotes": ["error", "double"],
+    "no-empty-blocks": "off",
+    "security/enforce-explicit-visibility": ["error"],
+    "security/no-block-members": ["warning"],
+    "security/no-inline-assembly": ["warning"]
+  }
+}

--- a/packages/haechi-cli/scripts/init.js
+++ b/packages/haechi-cli/scripts/init.js
@@ -83,19 +83,6 @@ module.exports = async function(name, options) {
       path.join(__dirname, '../', 'contracts/libs'),
       path.join('./', 'contracts', 'libs')
     );
-
-    fs.copySync(
-      path.join(__dirname, '../', '.solcover.js'),
-      path.join('./.solcover.js')
-    );
-    fs.copySync(
-      path.join(__dirname, '../', '.soliumrc.json'),
-      path.join('./.soliumrc.json')
-    );
-    fs.copySync(
-      path.join(__dirname, '../', '.soliumignore'),
-      path.join('./.soliumignore')
-    );
   }
 
   function printEndMsg(options) {
@@ -109,7 +96,7 @@ module.exports = async function(name, options) {
       options
     );
     printOrSilent(
-      `  Visit ${chalk.bold(packageJson.repository)} for ${chalk.green(
+      `  Clone ${chalk.bold(packageJson.repository.url)} for ${chalk.green(
         'Contributing!'
       )}`,
       options


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/HAECHI-LABS/HAECHI-CLI/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] PR to dev branch


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1. Can't call init.
Error logs:
```
{ Error: ENOENT: no such file or directory, stat '/Users/jchoy/dev/Haechi/vvisp/packages/haechi-cli/.solcover.js'
...
```
It is because the package structure has been changed

2. Success message
```
Initializing Directory...
Success Initializing Directory!

  Run haechi -h for more information on specific commands.
  Visit [object Object] for Contributing!
```

## What is the new behavior?
1. Move solium files to `referenFiles/`.

2. Clone https://github.com/HAECHI-LABS/haechi-cli.git for Contributing!

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

