### PR TITLE
fix: fix bug about variable convention in deploy-service

### DIFF
--- a/packages/vvisp/contracts/test/SecondA.sol
+++ b/packages/vvisp/contracts/test/SecondA.sol
@@ -4,15 +4,13 @@ pragma solidity ^0.4.23;
 contract SecondA {
     address addressB;
     address addressC;
-    address owner;
 
-    constructor(address _addressB, address _addressC, address _owner) public {
+    constructor(address _addressB, address _addressC, address[] _owners) public {
         addressB = _addressB;
         addressC = _addressC;
-        owner = _owner;
     }
 
-    function initialize(address _token, address _owner, address _addressA) public {
+    function initialize(address _token, address _owner, address[] _addressA) public {
         // something
     }
 }

--- a/packages/vvisp/scripts/deploy-service/processes/deployNonUpgradeables.js
+++ b/packages/vvisp/scripts/deploy-service/processes/deployNonUpgradeables.js
@@ -84,11 +84,11 @@ module.exports = async function(deployState, options) {
         for (let j = 0; j < contract.childNode.length; j++) {
           const childNodePath = contract.childNode[j].split('/');
           const childNode = stateClone.contracts[childNodePath[0]];
-          const arguments =
+          let arguments =
             childNodePath[1] === CONSTRUCTOR
               ? childNode[childNodePath[1]]
               : childNode[childNodePath[1]].arguments;
-          arguments[childNodePath[2]] = receipt.contractAddress;
+          injectAddress(arguments, childNodePath, 2, receipt.contractAddress);
           let notRemoved = true;
           _.remove(childNode.parentNode, function(parent) {
             const result = notRemoved && parent === name;
@@ -159,4 +159,18 @@ module.exports = async function(deployState, options) {
     )}\n`,
     options
   );
+
+  function injectAddress(_arguments, _path, _index, contractAddress) {
+    const argumentIndex = _path[_index];
+    if (Array.isArray(_arguments[argumentIndex])) {
+      injectAddress(
+        _arguments[argumentIndex],
+        _path,
+        _index + 1,
+        contractAddress
+      );
+    } else {
+      _arguments[argumentIndex] = contractAddress;
+    }
+  }
 };

--- a/packages/vvisp/scripts/deploy-service/processes/injectVar.js
+++ b/packages/vvisp/scripts/deploy-service/processes/injectVar.js
@@ -23,8 +23,19 @@ module.exports = function(deployState) {
       _type === CONSTRUCTOR
         ? _contract[CONSTRUCTOR]
         : _contract[INITIALIZE].arguments;
+    const _path = `${_name}/${_type}`;
 
+    _injecting(_variables, _stateClone, _path, _arguments, _contract);
+  }
+
+  function _injecting(_variables, _stateClone, _path, _arguments, _contract) {
+    const [name, type] = _path.split('/');
     for (let i = 0; i < _arguments.length; i++) {
+      const newPath = `${_path}/${i}`;
+      if (Array.isArray(_arguments[i])) {
+        _injecting(_variables, _stateClone, newPath, _arguments[i], _contract);
+        continue;
+      }
       const variable = getVar(_arguments[i]);
       if (!variable) {
         continue;
@@ -39,8 +50,8 @@ module.exports = function(deployState) {
           if (!dependency['childNode']) {
             dependency['childNode'] = [];
           }
-          dependency['childNode'].push(`${_name}/${_type}/${i}`);
-          if (_type === CONSTRUCTOR) {
+          dependency['childNode'].push(newPath);
+          if (type === CONSTRUCTOR) {
             if (!_contract['parentNode']) {
               _contract['parentNode'] = [];
             }
@@ -56,7 +67,7 @@ module.exports = function(deployState) {
         // Inject Variable
         _arguments[i] = _variables[splits[1]];
       } else {
-        throw new Error(`Wrong Expression at ${_name}, ${_arguments[i]}`);
+        throw new Error(`Wrong Expression at ${name}, ${_arguments[i]}`);
       }
     }
   }

--- a/packages/vvisp/test/dummy/justNonUpgradeables.service1.json
+++ b/packages/vvisp/test/dummy/justNonUpgradeables.service1.json
@@ -1,7 +1,8 @@
 {
   "serviceName": "Haechi",
   "variables" : {
-    "owner" : "0xb5F4E40c8177Ad63B19D4D3a254a5758771f57d0"
+    "owner" : "0xb5F4E40c8177Ad63B19D4D3a254a5758771f57d0",
+    "value1": 1
   },
   "contracts": {
     "DependencyA": {
@@ -28,7 +29,7 @@
     "DependencyD": {
       "path": "contracts/test/DependencyD.sol",
       "constructorArguments": [
-        [1,2,3],
+        ["${variables.value1}",2,3],
         "${variables.owner}"
       ]
     }

--- a/packages/vvisp/test/dummy/justNonUpgradeables.service2.json
+++ b/packages/vvisp/test/dummy/justNonUpgradeables.service2.json
@@ -1,7 +1,8 @@
 {
   "serviceName": "Haechi",
   "variables" : {
-    "owner" : "0xb5F4E40c8177Ad63B19D4D3a254a5758771f57d0"
+    "owner" : "0xb5F4E40c8177Ad63B19D4D3a254a5758771f57d0",
+    "value1": 1
   },
   "contracts": {
     "DependencyA": {
@@ -28,7 +29,7 @@
     "DependencyD": {
       "path": "contracts/test/DependencyD.sol",
       "constructorArguments": [
-        [1,2,3],
+        ["${variables.value1}",2,3],
         "${variables.owner}"
       ]
     },
@@ -37,14 +38,14 @@
       "constructorArguments": [
         "${contracts.SecondC.address}",
         "${contracts.DependencyD.address}",
-        "${contracts.SecondC.address}"
+        ["${contracts.SecondC.address}", "${variables.owner}"]
       ],
       "initialize": {
         "functionName": "initialize",
         "arguments": [
           "${contracts.SecondD.address}",
           "${variables.owner}",
-          "${contracts.SecondD.address}"
+          ["${contracts.SecondC.address}", "${variables.owner}"]
         ]
       }
     },

--- a/packages/vvisp/test/dummy/service2.json
+++ b/packages/vvisp/test/dummy/service2.json
@@ -83,14 +83,14 @@
       "constructorArguments": [
         "${contracts.SecondB.address}",
         "${contracts.DependencyD.address}",
-        "${contracts.SecondC.address}"
+        ["${contracts.SecondC.address}", "${variables.owner}"]
       ],
       "initialize": {
         "functionName": "initialize",
         "arguments": [
           "${contracts.SecondD.address}",
           "${variables.owner}",
-          "${contracts.SecondB.address}"
+          ["${contracts.SecondC.address}", "${variables.owner}"]
         ]
       }
     },


### PR DESCRIPTION
There is bug about deploy-service which can't change
varName.var or contracts.Contract.address in array input.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/HAECHI-LABS/vvisp/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] PR to dev branch


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
At service.vvisp.json,
```
constructorArguments: [
  ['${variables.owner}', '${contracts.ContractName.address}']
]
```
can't change variable conventions.

## What is the new behavior?

Work.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

