### PR TITLE
refactor: replace Object.keys, Object.values with Object.entries

### DIFF
--- a/packages/vvisp/scripts/compile.js
+++ b/packages/vvisp/scripts/compile.js
@@ -20,18 +20,17 @@ module.exports = async function(files, options) {
 
   const output = await compile(files, options);
 
-  const contractNames = Object.keys(output.contracts);
-  const contractContents = Object.values(output.contracts);
-
   // TODO: output file refine
-  for (let i = 0; i < contractNames.length; i++) {
-    const contractName = path.parse(contractNames[i]).name;
-    contractContents[i].contractName = contractName;
-    fs.writeJsonSync(
-      path.join('./build/contracts/', contractName + '.json'),
-      contractContents[i],
-      { spaces: '  ' }
-    );
-  }
+  Object.entries(output.contracts).forEach(
+    ([contractNamePath, contractContent]) => {
+      const contractName = path.parse(contractNamePath).name;
+      contractContent.contractName = contractName;
+      fs.writeJsonSync(
+        path.join('./build/contracts', contractName + '.json'),
+        contractContent,
+        { spaces: '  ' }
+      );
+    }
+  );
   printOrSilent('Compiling Finished!', options);
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/HAECHI-LABS/vvisp/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] PR to dev branch


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Compile script is currently using `Object.keys` and `Object.values` simultaneously which can be reduced by `Object.entries`.

## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
