### PR TITLE
fix: fix bug about #123

### DIFF
--- a/packages/vvisp-contracts/package.json
+++ b/packages/vvisp-contracts/package.json
@@ -26,6 +26,6 @@
     "upgradeable"
   ],
   "dependencies": {
-    "openzeppelin-solidity": "^2.1.0"
+    "openzeppelin-solidity": "2.1.3"
   }
 }

--- a/packages/vvisp-utils/package.json
+++ b/packages/vvisp-utils/package.json
@@ -54,7 +54,7 @@
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
-    "openzeppelin-solidity": "^2.1.0"
+    "openzeppelin-solidity": "2.1.3"
   },
   "nyc": {
     "exclude": [

--- a/packages/vvisp/package.json
+++ b/packages/vvisp/package.json
@@ -60,7 +60,7 @@
     "lodash": "^4.17.10",
     "mustache": "^2.3.2",
     "node-find-folder": "^0.1.32",
-    "openzeppelin-solidity": "^2.1.0",
+    "openzeppelin-solidity": "2.1.3",
     "rollup": "^0.65.0",
     "rollup-plugin-babel": "^3.0.7",
     "rollup-plugin-regenerator": "^0.6.0",

--- a/packages/vvisp/referenceFiles/package.json
+++ b/packages/vvisp/referenceFiles/package.json
@@ -24,7 +24,7 @@
     "ganache-cli": "6.1.0",
     "husky": "^1.2.1",
     "lint-staged": "^8.1.0",
-    "openzeppelin-solidity": "^2.1.0",
+    "openzeppelin-solidity": "2.1.3",
     "prettier": "^1.15.3",
     "solidity-coverage": "git+https://github.com/rotcivegaf/solidity-coverage.git#5875f5b7bc74d447f3312c9c0e9fc7814b482477",
     "solium": "^1.1.6",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/HAECHI-LABS/vvisp/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ x PR to dev branch


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #123

Currently, vvisp has a dependency on `openzeppelin-solidity` library. The version is specified as `"openzeppelin-solidity": "^2.1.0"` in package.json which means allowing update to the most recent major version as long as the first number of version matches.

However, openzeppelin released 2.2.0 version with chaning "pragma solidity" statement versioning to "^0.5.2". (You can see the change in this PR: https://github.com/OpenZeppelin/openzeppelin-solidity/commit/b7d60f2f9a849c5c2d59e24062f9c09f3390487a#diff-ff7dca5f7cee2c9e49ab96d5f85d00a0)

In vvisp, the pragma statement for all contracts is `pragma solidity >=0.5.0 <0.6.0;` which doesn't match with openzeppelin 2.2.0 version's. So there are 2 solution.
1: Downgrade openzeppelin version to 2.1.3
2: Modify pragma statement for all contracts in vvisp.

I think 1 is better than 2, so I downgraded the version of openzeppelin-solidity to 2.1.3.

## What is the new behavior?
After this PR merged, `vvisp init && npm install` command will install `openzeppelin-solidity` package of 2.1.3 version. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
