### PR TITLE
docs: add 'options' for deploy-service, deploy-contract commands

### DIFF
--- a/packages/vvisp/commands/README-ko.md
+++ b/packages/vvisp/commands/README-ko.md
@@ -103,18 +103,18 @@ build/contracts/
 
 대상 컨트랙트를 배포합니다.
 
-__Examples__
-
-```shell
-$ vvisp deploy-contract contracts/ContractA.sol input1 input2
-```
-
 __Options__
 
 `-n, --network <network>`: 배포할 네트워크를 설정합니다.  
 `--gasLimit <gasLimit>` : 배포 시 사용할 gasLimit을 설정합니다.  
 `--gasPrice <privateKey>` : 배포 시 1 gas 당 지불할 gasPrice를 설정합니다.  
-`--from <privateKey>` : privateKey를 통해 배포할 계정을 설정합니다.  
+`--from <privateKey>` : privateKey를 통해 배포할 계정을 설정합니다.
+
+__Examples__
+
+```shell
+$ vvisp deploy-contract contracts/ContractA.sol input1 input2
+```  
 
 __Outputs__ 
 

--- a/packages/vvisp/commands/README-ko.md
+++ b/packages/vvisp/commands/README-ko.md
@@ -108,6 +108,14 @@ __Examples__
 ```shell
 $ vvisp deploy-contract contracts/ContractA.sol input1 input2
 ```
+
+__Options__
+
+`-n, --network <network>`: 배포할 네트워크를 설정합니다.  
+`--gasLimit <gasLimit>` : 배포 시 사용할 gasLimit을 설정합니다.  
+`--gasPrice <privateKey>` : 배포 시 1 gas 당 지불할 gasPrice를 설정합니다.  
+`--from <privateKey>` : privateKey를 통해 배포할 계정을 설정합니다.  
+
 __Outputs__ 
 
 ```shell
@@ -132,6 +140,13 @@ Contract Address : 0xcfb...
 **특별한 경우가 아니면 `state.vvisp.json`의 변경은 추천드리지 않습니다.**
 
 `service.vvisp.json`의 작성은 [이곳](../../../CONFIGURATION-ko.md#service)을 참고하십시오.
+
+__Options__
+
+`-n, --network <network>`: 배포할 네트워크를 설정합니다.  
+`--gasLimit <gasLimit>` : 배포 시 사용할 gasLimit을 설정합니다.  
+`--gasPrice <privateKey>` : 배포 시 1 gas 당 지불할 gasPrice를 설정합니다.  
+`--from <privateKey>` : privateKey를 통해 배포할 계정을 설정합니다.  
 
 __Example__
 

--- a/packages/vvisp/commands/README.md
+++ b/packages/vvisp/commands/README.md
@@ -105,11 +105,19 @@ build/contracts/
 
 Deploy the target contract.
 
+__Options__
+
+`-n, --network <network>`: specify the network to deploy on.  
+`--gasLimit <gasLimit>` : specify gasLimit to use for deploying.  
+`--gasPrice <privateKey>` : specify gasPrice to use for deploying.  
+`--from <privateKey>` : specify privateKey to use for deploying.  
+
 __Examples__
 
 ```shell
 $ vvisp deploy-contract contracts/ContractA.sol input1 input2
 ```
+
 __Outputs__ 
 
 ```shell
@@ -136,6 +144,13 @@ If deployment fails due to an unexpected problem during deployment, re-enter the
 **It is not recommended to change `state.vvisp.json` unless it is a special case.**
 
 To create `service.vvisp.json`, see [here](../../../CONFIGURATION.md#service).
+
+__Options__
+
+`-n, --network <network>`: specify the network to deploy on.  
+`--gasLimit <gasLimit>` : specify gasLimit to use for deploying.  
+`--gasPrice <privateKey>` : specify gasPrice to use for deploying.  
+`--from <privateKey>` : specify privateKey to use for deploying.  
 
 __Example__
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/HAECHI-LABS/vvisp/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] PR to dev branch


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
There is no explanation of "--from, --gasLimit, --gasPrice, --network" options for `deploy-service`, `deploy-contract` commands which actually exists but not written in README. It would be useful for developer to know this options exist.

## What is the new behavior?
Explain options "--from, --gasLimit, --gasPrice, --network" for `deploy-contract`, `deploy-service` commands

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
