### PR TITLE
fix: fix #126 change .babelrc presets for supporting spread(...) operator

### DIFF
--- a/packages/vvisp/referenceFiles/.babelrc
+++ b/packages/vvisp/referenceFiles/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["env"]
+  "presets": ["es2015", "stage-2", "stage-3"]
 }

--- a/packages/vvisp/referenceFiles/.babelrc
+++ b/packages/vvisp/referenceFiles/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "stage-2", "stage-3"]
+  "presets": ["env"]
 }

--- a/packages/vvisp/referenceFiles/package.json
+++ b/packages/vvisp/referenceFiles/package.json
@@ -14,9 +14,7 @@
   "devDependencies": {
     "@haechi-labs/vvisp-utils": "^1.0.0",
     "@haechi-labs/vvisp-contracts": "^1.0.0",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.7.0",
-    "babel-register": "^6.23.0",
     "coveralls": "^3.0.1",
     "eth-gas-reporter": "^0.1.7",
     "ethereumjs-util": "^5.1.2",

--- a/packages/vvisp/referenceFiles/truffle-config.js
+++ b/packages/vvisp/referenceFiles/truffle-config.js
@@ -1,6 +1,3 @@
-require('babel-register');
-require('babel-polyfill');
-
 module.exports = {
   networks: {
     development: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/HAECHI-LABS/vvisp/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] PR to dev branch


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #126 

## What is the new behavior?
It seems babel throws an error for ES6 spread operator (`...`). 
Since vvisp uses babel 6 version, for babel to parse spread operator, "stage-3" preset should be added in `.babelrc`. 
After this PR merged, `vvisp init` command will initialize .babelrc within presets: ["es2015", "stage-2", "stage-3"].

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
