### PR TITLE
Jay/divide default evm version

### DIFF
--- a/packages/vvisp-utils/src/Config.js
+++ b/packages/vvisp-utils/src/Config.js
@@ -9,7 +9,6 @@ const DEFAULT_NETWORK = 'development';
 const getConfigRoot = require('./getConfigRoot');
 const getPrivateKey = require('./getPrivateKey');
 const filterPrivateKey = require('./filterPrivateKey');
-const printOrSilent = require('./printOrSilent');
 const forIn = require('./forIn');
 
 const web3Store = require('./web3Store');
@@ -38,8 +37,7 @@ function Config() {
           optimizer: {
             enabled: true,
             runs: 200
-          },
-          evmVersion: 'petersburg'
+          }
         }
       },
       vyper: {}
@@ -304,6 +302,19 @@ Config.load = options => {
 
   if (!config.platform) {
     config.platform = DEFAULT_PLATFORM;
+  }
+
+  if (!config.compilers.solc.settings.evmVersion) {
+    switch (config.platform) {
+      case ETHEREUM: {
+        config.compilers.solc.settings.evmVersion = 'petersburg';
+        break;
+      }
+      case KLAYTN: {
+        config.compilers.solc.settings.evmVersion = 'byzantium';
+        break;
+      }
+    }
   }
 
   return config;

--- a/packages/vvisp-utils/src/Config.js
+++ b/packages/vvisp-utils/src/Config.js
@@ -315,6 +315,13 @@ Config.load = options => {
         break;
       }
     }
+  } else if (
+    config.platform === KLAYTN &&
+    config.compilers.solc.settings.evmVersion === 'petersburg'
+  ) {
+    throw new Error(
+      'Notice, Klaytn platform does not support petersburg evmVersion currently, change it to byzantium'
+    );
   }
 
   return config;

--- a/packages/vvisp-utils/test/Config.test.js
+++ b/packages/vvisp-utils/test/Config.test.js
@@ -14,7 +14,7 @@ const DEFAULT_TX_OPTIONS = {
   gasLimit: 6721975,
   gasPrice: 10000000000 // 10 gwei,
 };
-const { DEFAULT_NETWORK, DEFAULT_PLATFORM } = require('../constants');
+const { DEFAULT_NETWORK, DEFAULT_PLATFORM, KLAYTN } = require('../constants');
 
 const SAMPLE_CONFIG_PATH = path.join(
   __dirname,
@@ -261,6 +261,14 @@ describe('# Config test', function() {
         config.compilers = compilers;
         expect(config.compilers).to.deep.equal(compilers);
       });
+
+      it('should throw error when platform is klaytn and evmVersion is petersburg', function() {
+        Config.delete();
+        config.platform = KLAYTN;
+        expect(() => {
+          Config.get();
+        }).to.throw(Error);
+      });
     });
 
     describe('#from', function() {
@@ -410,6 +418,10 @@ describe('# Config test', function() {
 
       describe('#platform', function() {
         const TEST_NETWORK = 'coverage';
+        beforeEach(function() {
+          config.networks[TEST_NETWORK].platform = KLAYTN;
+        });
+
         it('should return default platform when network is not set', function() {
           expect(config.platform).to.equal(DEFAULT_PLATFORM);
         });

--- a/packages/vvisp-utils/test/dummy/sample.vvisp-config.js
+++ b/packages/vvisp-utils/test/dummy/sample.vvisp-config.js
@@ -6,7 +6,6 @@ module.exports = {
       network_id: '*' // eslint-disable-line camelcase
     },
     coverage: {
-      platform: 'klaytn',
       host: 'localhost',
       port: 8545,
       network_id: '*', // eslint-disable-line camelcase


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/HAECHI-LABS/vvisp/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] PR to dev branch


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue number: #148 
No error handling about `petersburg` in Klaytn.


## What is the new behavior?
Default evmVersion is divided.
It throws error if the evmVersion is `petersburg` when platform is klaytn.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
