### PR TITLE
feat: add error handling about network and output of chosen network

### DIFF
--- a/packages/vvisp-utils/src/Config.js
+++ b/packages/vvisp-utils/src/Config.js
@@ -296,8 +296,14 @@ Config.load = options => {
   config.merge(fileConfig);
   config.merge(options);
 
-  if (!config.network && config.networks.hasOwnProperty(DEFAULT_NETWORK)) {
+  if (!config.network) {
     config.network = DEFAULT_NETWORK;
+  }
+
+  if (!config.networks.hasOwnProperty(config.network)) {
+    const networkMessage =
+      config.network + (config.network === DEFAULT_NETWORK ? '(default)' : '');
+    throw new Error('A network named ' + networkMessage + ' does not exist');
   }
 
   if (!config.platform) {

--- a/packages/vvisp/scripts/utils/injectConfig.js
+++ b/packages/vvisp/scripts/utils/injectConfig.js
@@ -17,11 +17,14 @@ module.exports = function(options = {}) {
 
   if (options.platform === 'klaytn') {
     printOrSilent(
-      '\nIn Klaytn, the gasPrice is fixed at 25ston(25000000000). No other values are allowed.'
+      '\nIn Klaytn, the gasPrice is fixed at 25ston(25000000000). No other values are allowed.',
+      options
     );
-    printOrSilent('GasPrice is changed to 25ston.\n');
+    printOrSilent('GasPrice is changed to 25ston.\n', options);
     config.gasPrice = 25000000000;
   }
+
+  printOrSilent('Network: ' + options.config.network, options);
 
   return options;
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/HAECHI-LABS/vvisp/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] PR to dev branch


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe: 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No guide about network currently using.
No error handling about invalid network name.


## What is the new behavior?

The network name will be came out in the console.
Error will come out when user puts invalid network name.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
